### PR TITLE
Add assets manifest for Sprockets 4.x compatibility

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-nodejs 20.9.0
-ruby 3.0.6
-bundler 2.3.26
+nodejs 20.15.0
+ruby 3.3.4
+bundler 2.5.16

--- a/app/assets/config/camaleon_editor.js
+++ b/app/assets/config/camaleon_editor.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_tree ../javascripts
+//= link_tree ../stylesheets


### PR DESCRIPTION
Sprockets 4.x changed the default logic for determining top-level targets for asset compilation. If you are mounting Rails engines which provide their own assets, check to see if they define their own manifest file.

See https://github.com/rails/sprockets/blob/main/UPGRADING.md#manifestjs
